### PR TITLE
Ensure sans-serif fonts are used

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -1,5 +1,5 @@
 html {
-  font-family: Roboto, "Helvetica Neue", "Open Sans", "Sans"; }
+  font-family: Roboto, "Helvetica Neue", "Open Sans", "Sans", sans-serif; }
 
 body {
   margin: 0;


### PR DESCRIPTION
Noticed while looking at the site on Windows that all the fonts were displaying with serifs:

![screenshot of the site with serif text ):](https://puu.sh/w9Gqr/13745cbe9b.png)

Based on the selection of fonts listed in the CSS, I'm pretty sure this wasn't what you were going for! This PR adds `sans-serif` on to the end of the font stack so that it'll always fall back to a sans-serif font if the listed ones aren't found.

I've done the bare minimum fix here, but it's worth asking - was your intent to use the system/default fonts where applicable? If so, it might be worth switching to something like [this](https://medium.com/skyscanner-design/a-native-font-stack-d9d0db72d6e6) to ensure things work well on all platforms. I can update this PR if that's something you'd be interested in!